### PR TITLE
Add printable resume web layout

### DIFF
--- a/resume/README.md
+++ b/resume/README.md
@@ -1,0 +1,41 @@
+# Resume web view
+
+This folder contains a self-contained, static implementation of a two-page resume that mirrors the layout of the source PDF while staying simple to edit and host.
+
+## Stack choices
+- **Plain HTML, CSS, and vanilla JavaScript**: easy to inspect and modify without build tooling.
+- **Google Fonts (Rubik)**: matches the typography from the original design with a reliable web-hosted source.
+- **LocalStorage persistence**: edits you make in the browser are saved locally without any backend services.
+
+## Project structure
+- `index.html` — entry point with a minimal toolbar and containers for the two-page layout.
+- `styles.css` — typography, spacing tokens, layout grid, and print rules. Adjust CSS variables near the top to tweak sizing and colors.
+- `script.js` — renders resume data into the layout, toggles edit mode, and saves changes.
+- `data/resume.json` — default resume content and variants. Edit this to change the canonical copy that loads for first-time visitors.
+
+## Editing content
+1. Open `resume/index.html` in your browser (see "Run locally").
+2. Click **Enable editing** in the toolbar.
+3. Click any highlighted text to edit in place. Changes save automatically to your browser.
+4. Use **Reset content** to reload the defaults from `data/resume.json`.
+
+To change the default copy shipped with the site, edit the strings in `data/resume.json` and commit the file. The data model nests under `variants` to make future additions (like multiple targeted resumes or AI-assisted editing) straightforward.
+
+## Layout and typography tweaks
+- Typography, spacing, and accent colors are controlled via CSS variables at the top of `styles.css`.
+- The layout is grid-based; adjust column ratios in the `.grid` rule if you want different column widths.
+- Print styles are defined under `@media print` and the `@page` rule. The layout is sized for US Letter with generous margins; adjust the `--page-width`, `--page-height`, and `--page-padding` variables for other sizes.
+
+## Print behavior
+The layout is designed to render as exactly two pages. The browser print dialog will use the print-specific rules (no toolbar, neutral background) and the `@page` sizing to export a clean PDF.
+
+## Persistence approach
+Edits are stored in `localStorage` under the key `resume-data-v1`. Clearing site data or using a private window resets to the defaults in `data/resume.json`.
+
+## Run locally / hosting
+- Serve the `resume/` folder with a simple static server to keep `fetch` working for `data/resume.json`, e.g. `python -m http.server 8000` from the repo root and visit `http://localhost:8000/resume/`.
+- To host, publish the `resume/` directory on any static hosting service (GitHub Pages, Netlify, S3). No build step is required.
+
+## Future-friendly structure
+- The `variants` object in `data/resume.json` is ready for multiple named resume versions.
+- `script.js` isolates rendering, editing, and persistence so additional features (like AI-powered editing) can hook into the same data structure without changing the layout code.

--- a/resume/data/resume.json
+++ b/resume/data/resume.json
@@ -1,0 +1,113 @@
+{
+  "defaultVariant": "general",
+  "variants": {
+    "general": {
+      "name": "Alex Doe",
+      "role": "Product & AI Strategy Leader",
+      "summary": "Product leader focused on shipping trustworthy AI experiences. I blend strategy, execution, and facilitation to help teams ship quickly while keeping customers at the center.",
+      "contact": {
+        "lines": [
+          "San Francisco, CA • (415) 555-0198",
+          "alex.doe@email.com • alexd.dev",
+          "linkedin.com/in/alexdoe"
+        ]
+      },
+      "skills": [
+        "Roadmapping & prioritization",
+        "AI safety & evaluation",
+        "Product discovery",
+        "Experiment design",
+        "Research synthesis",
+        "Storytelling & facilitation",
+        "Stakeholder alignment",
+        "Data-informed decisioning",
+        "Team leadership"
+      ],
+      "experience": [
+        {
+          "title": "Director of Product, AI Experiences",
+          "location": "Northbeam • 2022 – Present",
+          "period": "San Francisco, CA",
+          "bullets": [
+            "Lead AI product strategy for marketing intelligence suite serving 1,200+ brands.",
+            "Shipped conversational analysis workflows that reduced manual reporting time by 45%.",
+            "Partnered with legal and security teams to roll out responsible AI guardrails for all experiments.",
+            "Built evaluation harness combining synthetic data and human review to measure model quality weekly.",
+            "Coached PMs and designers on prompt design, model debugging, and fast experiment loops."
+          ],
+          "tags": ["LLM evaluations", "Product strategy", "Team leadership"]
+        },
+        {
+          "title": "Senior Product Manager, Core Platform",
+          "location": "AtlasOS • 2019 – 2022",
+          "period": "Remote",
+          "bullets": [
+            "Owned roadmap for collaboration layer used by 300k monthly active users.",
+            "Ran discovery with enterprise admins; prioritized permissions overhaul that cut support tickets by 30%.",
+            "Instrumented feature health metrics and led weekly operational reviews with engineering leads.",
+            "Partnered with customer success to pilot onboarding revamp, improving activation by 12%."
+          ],
+          "tags": ["SaaS", "Operational cadence", "Customer research"]
+        },
+        {
+          "title": "Product Manager, Growth",
+          "location": "Brightline • 2017 – 2019",
+          "period": "New York, NY",
+          "bullets": [
+            "Launched referral and win-back programs that increased weekly signups by 18%.",
+            "Shipped lifecycle email framework tied to user milestones; improved free-to-paid conversion by 9%.",
+            "Created analytics dashboards tracking activation, retention, and engagement across cohorts."
+          ],
+          "tags": ["Growth loops", "Lifecycle messaging", "Experimentation"]
+        },
+        {
+          "title": "Consultant, Product Operations",
+          "location": "Independent • 2015 – 2017",
+          "period": "Remote",
+          "bullets": [
+            "Advised seed-stage teams on OKR design, decision rituals, and customer interview programs.",
+            "Facilitated roadmap alignment workshops for cross-functional leadership teams.",
+            "Created lightweight scorecards to evaluate experiment impact before build."
+          ],
+          "tags": ["Workshops", "OKRs", "Decision quality"]
+        }
+      ],
+      "projects": [
+        {
+          "title": "AI Evaluation Playbook",
+          "location": "Personal research",
+          "period": "2024",
+          "bullets": [
+            "Designed repeatable rubric for LLM feature launches covering safety, reliability, and UX quality.",
+            "Open-sourced prompt libraries and test suites used by 3 product teams."
+          ],
+          "tags": ["Evaluation", "Prompting", "Open source"]
+        },
+        {
+          "title": "Discovery Workshop Kit",
+          "location": "Facilitation toolkit",
+          "period": "2023",
+          "bullets": [
+            "Packaged Miro templates, scripts, and research briefs to help teams run 90-minute discovery sessions.",
+            "Adopted by 12 startups to accelerate customer learning."
+          ],
+          "tags": ["Facilitation", "Templates"]
+        }
+      ],
+      "education": [
+        {
+          "title": "MBA, Strategy & Operations",
+          "location": "UC Berkeley, Haas School of Business",
+          "period": "2015",
+          "bullets": ["Product leadership fellow; led design thinking workshops for incoming students."]
+        },
+        {
+          "title": "B.S. Cognitive Science",
+          "location": "University of Washington",
+          "period": "2010",
+          "bullets": ["Research assistant in human-computer interaction lab."]
+        }
+      ]
+    }
+  }
+}

--- a/resume/index.html
+++ b/resume/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Resume</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="app">
+    <header class="toolbar">
+      <div class="toolbar__title">Resume viewer</div>
+      <div class="toolbar__actions">
+        <button id="toggle-edit" aria-label="Toggle edit mode">Enable editing</button>
+        <button id="reset-content" aria-label="Reset content to defaults">Reset content</button>
+        <button id="print" aria-label="Print resume">Print</button>
+      </div>
+    </header>
+    <main id="resume"></main>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/resume/script.js
+++ b/resume/script.js
@@ -1,0 +1,252 @@
+const STORAGE_KEY = 'resume-data-v1';
+
+const state = {
+  data: null,
+  editMode: false,
+  variant: null,
+};
+
+function loadDefaultData() {
+  return fetch('data/resume.json').then((resp) => resp.json());
+}
+
+function loadStoredData() {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (!saved) return null;
+  try {
+    return JSON.parse(saved);
+  } catch (err) {
+    console.warn('Could not parse stored data, falling back to defaults', err);
+    return null;
+  }
+}
+
+function saveData() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({
+    variant: state.variant,
+    data: state.data,
+  }));
+}
+
+function createEditable(tag, text, path, className = '') {
+  const el = document.createElement(tag);
+  el.textContent = text;
+  el.dataset.path = path;
+  el.dataset.editable = 'true';
+  if (className) el.className = className;
+  return el;
+}
+
+function setValueAtPath(obj, path, value) {
+  const steps = path.split('.');
+  let current = obj;
+  for (let i = 0; i < steps.length - 1; i += 1) {
+    current = current[steps[i]];
+  }
+  current[steps.at(-1)] = value;
+}
+
+function handleEdit(event) {
+  const target = event.target;
+  if (target.dataset.editable !== 'true') return;
+  const path = target.dataset.path;
+  setValueAtPath(state.data, path, target.textContent.trim());
+  saveData();
+}
+
+function buildContact(contact) {
+  const container = document.createElement('div');
+  container.className = 'contact';
+
+  contact.lines.forEach((text, index) => {
+    const p = createEditable('div', text, `contact.lines.${index}`, 'contact__line');
+    container.appendChild(p);
+  });
+
+  return container;
+}
+
+function buildTags(tags, pathPrefix) {
+  const tagContainer = document.createElement('div');
+  tagContainer.className = 'tags';
+  tags.forEach((tag, index) => {
+    const span = createEditable('span', tag, `${pathPrefix}.${index}`, 'tag');
+    tagContainer.appendChild(span);
+  });
+  return tagContainer;
+}
+
+function buildList(items, pathPrefix) {
+  const list = document.createElement('div');
+  list.className = 'list';
+
+  items.forEach((item, index) => {
+    const wrapper = document.createElement('div');
+
+    const title = createEditable('h4', item.title, `${pathPrefix}.${index}.title`, 'list__item-title');
+    const meta = document.createElement('div');
+    meta.className = 'list__item-meta';
+    const location = createEditable('span', item.location, `${pathPrefix}.${index}.location`);
+    const period = createEditable('span', item.period, `${pathPrefix}.${index}.period`);
+    meta.append(location, period);
+
+    wrapper.append(title, meta);
+
+    if (item.bullets && item.bullets.length) {
+      const bullets = document.createElement('ul');
+      bullets.className = 'bullets';
+      item.bullets.forEach((bullet, bulletIndex) => {
+        const li = document.createElement('li');
+        const bulletEl = createEditable('span', bullet, `${pathPrefix}.${index}.bullets.${bulletIndex}`);
+        li.appendChild(bulletEl);
+        bullets.appendChild(li);
+      });
+      wrapper.appendChild(bullets);
+    }
+
+    if (item.tags && item.tags.length) {
+      wrapper.appendChild(buildTags(item.tags, `${pathPrefix}.${index}.tags`));
+    }
+
+    list.appendChild(wrapper);
+  });
+
+  return list;
+}
+
+function buildSection(title, contentEl, className = '') {
+  const section = document.createElement('section');
+  section.className = `section ${className}`;
+
+  const heading = document.createElement('h3');
+  heading.className = 'section__title';
+  heading.textContent = title;
+  section.appendChild(heading);
+  section.appendChild(contentEl);
+  return section;
+}
+
+function buildSummary(text, path) {
+  const p = createEditable('p', text, path, 'section__content');
+  return p;
+}
+
+function buildPage(content, pageIndex) {
+  const page = document.createElement('article');
+  page.className = 'page';
+
+  const header = document.createElement('div');
+  header.className = 'page__header';
+  const title = createEditable('h1', content.name, 'name', 'page__title');
+  const role = createEditable('div', content.role, 'role', 'page__role');
+  const titleBlock = document.createElement('div');
+  titleBlock.append(title, role);
+
+  const contact = buildContact(content.contact);
+  header.append(titleBlock, contact);
+  page.appendChild(header);
+
+  const grid = document.createElement('div');
+  grid.className = 'grid';
+
+  if (pageIndex === 0) {
+    const summary = buildSection('Profile', buildSummary(content.summary, 'summary'));
+    summary.classList.add('full-width');
+    grid.appendChild(summary);
+
+    const skills = buildSection('Skills', buildTags(content.skills, 'skills'));
+    grid.appendChild(skills);
+
+    const experience = buildSection('Experience', buildList(content.experience.slice(0, 3), 'experience'));
+    experience.classList.add('full-width');
+    grid.appendChild(experience);
+  } else {
+    const additional = buildSection('Experience Continued', buildList(content.experience.slice(3), 'experience'));
+    additional.classList.add('full-width');
+    grid.appendChild(additional);
+
+    const projects = buildSection('Projects', buildList(content.projects, 'projects'));
+    projects.classList.add('full-width');
+    grid.appendChild(projects);
+
+    const education = buildSection('Education', buildList(content.education, 'education'));
+    education.classList.add('full-width');
+    grid.appendChild(education);
+  }
+
+  page.appendChild(grid);
+
+  const notice = document.createElement('div');
+  notice.className = 'notice';
+  notice.textContent = 'Enable editing to click any text, update it in place, and keep changes in this browser.';
+  page.appendChild(notice);
+
+  const footer = document.createElement('footer');
+  footer.textContent = 'Two-page layout is print ready. Use the browser print dialog to export to PDF or paper.';
+  page.appendChild(footer);
+
+  return page;
+}
+
+function render() {
+  const container = document.getElementById('resume');
+  container.classList.toggle('edit-mode', state.editMode);
+  container.innerHTML = '';
+
+  const page1 = buildPage(state.data, 0);
+  const page2 = buildPage(state.data, 1);
+  container.append(page1, page2);
+
+  const editables = container.querySelectorAll('[data-editable="true"]');
+  editables.forEach((el) => {
+    el.contentEditable = state.editMode;
+    el.removeEventListener('input', handleEdit);
+    if (state.editMode) {
+      el.addEventListener('input', handleEdit);
+    }
+  });
+
+  const toggleEdit = document.getElementById('toggle-edit');
+  toggleEdit.textContent = state.editMode ? 'Disable editing' : 'Enable editing';
+}
+
+function applyVariant(variantName, variants) {
+  state.variant = variantName;
+  state.data = JSON.parse(JSON.stringify(variants[variantName]));
+  saveData();
+  render();
+}
+
+async function init() {
+  const defaults = await loadDefaultData();
+  const stored = loadStoredData();
+
+  const activeVariant = stored?.variant || defaults.defaultVariant;
+  const baseData = stored?.data || defaults.variants[activeVariant];
+
+  state.variant = activeVariant;
+  state.data = JSON.parse(JSON.stringify(baseData));
+
+  const resume = document.getElementById('resume');
+  resume.addEventListener('click', (event) => {
+    if (!state.editMode) return;
+    if (event.target.dataset.editable === 'true') {
+      event.target.focus();
+    }
+  });
+
+  document.getElementById('toggle-edit').addEventListener('click', () => {
+    state.editMode = !state.editMode;
+    render();
+  });
+
+  document.getElementById('reset-content').addEventListener('click', () => {
+    applyVariant(defaults.defaultVariant, defaults.variants);
+  });
+
+  document.getElementById('print').addEventListener('click', () => window.print());
+
+  render();
+}
+
+init();

--- a/resume/styles.css
+++ b/resume/styles.css
@@ -1,0 +1,274 @@
+:root {
+  --page-width: 8.27in;
+  --page-height: 11.69in;
+  --page-padding: 0.75in;
+  --accent: #243b53;
+  --subtle: #8a95a5;
+  --text: #1f2933;
+  --bg: #f7f9fb;
+  --section-gap: 18px;
+  --line-height: 1.4;
+  --grid-gap: 22px;
+  --small-text: 0.92rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  font-family: 'Rubik', system-ui, -apple-system, sans-serif;
+  color: var(--text);
+}
+
+.app {
+  min-height: 100vh;
+  padding: 20px 0 40px;
+}
+
+.toolbar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #d9e2ec;
+  border-radius: 10px;
+  margin: 0 auto 18px;
+  padding: 12px 16px;
+  max-width: calc(var(--page-width) + 32px);
+  box-shadow: 0 8px 20px rgba(17, 24, 39, 0.08);
+  z-index: 10;
+}
+
+.toolbar__title {
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.toolbar__actions {
+  display: flex;
+  gap: 10px;
+}
+
+.toolbar button {
+  background: #eef2f7;
+  color: var(--accent);
+  border: 1px solid #d1d9e6;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.toolbar button:hover {
+  background: #e0e7f1;
+}
+
+#resume {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.page {
+  width: var(--page-width);
+  min-height: var(--page-height);
+  background: #ffffff;
+  border: 1px solid #d9e2ec;
+  border-radius: 12px;
+  padding: var(--page-padding);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.1);
+}
+
+.page + .page {
+  page-break-before: always;
+}
+
+.page__header {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 12px;
+  border-bottom: 2px solid #e5e8ef;
+  padding-bottom: 12px;
+  margin-bottom: 16px;
+}
+
+.page__title {
+  font-size: 1.65rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--accent);
+  margin: 0;
+}
+
+.page__role {
+  font-size: 1.05rem;
+  margin: 4px 0 0;
+  color: #52616b;
+}
+
+.contact {
+  text-align: right;
+  font-size: var(--small-text);
+  line-height: 1.35;
+}
+
+.contact a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1.35fr;
+  gap: var(--grid-gap);
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section__title {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  color: var(--accent);
+  margin: 0;
+}
+
+.section__content {
+  font-size: 0.98rem;
+  line-height: var(--line-height);
+  margin: 0;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.list__item-title {
+  margin: 0;
+  font-weight: 600;
+  color: #1b2a38;
+}
+
+.list__item-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--small-text);
+  color: var(--subtle);
+  margin-top: 2px;
+}
+
+.bullets {
+  margin: 6px 0 0 18px;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.bullets li {
+  line-height: 1.45;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.tag {
+  background: #eef2f7;
+  border-radius: 12px;
+  padding: 6px 10px;
+  font-size: 0.85rem;
+  color: #3b4a5a;
+}
+
+[data-editable="true"] {
+  border-radius: 6px;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.edit-mode [data-editable="true"] {
+  outline: 1px dashed #c5d3e6;
+  box-shadow: inset 0 0 0 1px #d7e3f5;
+}
+
+.edit-mode [data-editable="true"]:focus {
+  background: #f1f5fb;
+  outline: 1px solid #a3b7d6;
+}
+
+.notice {
+  font-size: 0.9rem;
+  color: #52616b;
+  background: #f1f5fb;
+  border: 1px solid #d7e3f5;
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+}
+
+footer {
+  font-size: var(--small-text);
+  color: var(--subtle);
+  text-align: right;
+  margin-top: 12px;
+}
+
+@media print {
+  :root {
+    --page-width: 8.5in;
+    --page-height: 11in;
+    --page-padding: 0.65in;
+  }
+
+  body {
+    background: white;
+  }
+
+  .toolbar {
+    display: none;
+  }
+
+  .app {
+    padding: 0;
+  }
+
+  #resume {
+    gap: 0;
+  }
+
+  .page {
+    box-shadow: none;
+    border: none;
+    border-radius: 0;
+    padding: var(--page-padding);
+  }
+
+  .notice,
+  footer {
+    display: none;
+  }
+
+  @page {
+    size: Letter;
+    margin: 0.65in;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static two-page resume site using Rubik typography, toolbar controls, and sectioned layout
- implement inline editing with localStorage persistence backed by a JSON-based variant data model
- document structure, typography overrides, print behavior, and hosting steps for the resume bundle

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d4c97eb48322bdacc3c08307e60d)